### PR TITLE
Rename `from_path` function to `load`, add `Load` trait.

### DIFF
--- a/changes/1.change.md
+++ b/changes/1.change.md
@@ -1,0 +1,1 @@
+The `from_path` function was renamed to `load` for consistency.

--- a/changes/1.feature.md
+++ b/changes/1.feature.md
@@ -1,0 +1,2 @@
+The `Load` sealed extension trait was added, which allows for ergonomic
+`path.load()` code.


### PR DESCRIPTION
- I've added the `Load` sealed extension trait, implemented for `P: AsRef<Path>`, which improves ergonomics similarly to `str::parse`.
- I've also renamed the `from_path` function to `load` for consistency.